### PR TITLE
CI/GitHub: Apply branch label to PRs when they are opened

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,10 +1,9 @@
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  pull_request_target:
+    types: [opened]
 
 jobs:
   pr_labeler:
-    if: github.repository == 'TrinityCore/TrinityCore'
     runs-on: ubuntu-latest
     name: Pull Request Labeler
     steps:


### PR DESCRIPTION
Apply branch label to PRs when they are opened instead of having a cron job that runs every 5 minutes. This uses the "new" github action type "pull_request_target"

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
